### PR TITLE
Improve client state

### DIFF
--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -94,6 +94,14 @@ impl<'a, const PROPERTIES_N: usize> Connect<'a, PROPERTIES_N> {
         }
         flags
     }
+
+    pub fn keep_alive(&self) -> u16 {
+        self.keep_alive
+    }
+
+    pub fn clean_start(&self) -> bool {
+        self.clean_start
+    }
 }
 
 impl<const PROPERTIES_N: usize> Packet for Connect<'_, PROPERTIES_N> {


### PR DESCRIPTION
Use a better model for state, so we can store info associated with connection when we are connected, and add in handling of clean start, session present and keep alive values, and produce associated errors.