### PR TITLE
Better reporting of non-error reason codes, more consistent names

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ async fn main() -> Result<(), ClientError> {
     let topic_name = "mountain-mqtt-example-topic";
     let retain = false;
 
-    client.subscribe(topic_name, QualityOfService::QoS0).await?;
+    client.subscribe(topic_name, QualityOfService::Qos0).await?;
 
     client
         .publish(
             topic_name,
             "Hello MQTT!".as_bytes(),
-            QualityOfService::QoS0,
+            QualityOfService::Qos0,
             retain,
         )
         .await?;

--- a/README.md
+++ b/README.md
@@ -136,3 +136,12 @@ async fn main() -> Result<(), ClientError> {
     Ok(())
 }
 ```
+
+## Miscellaneous
+
+The shortening "QoS" for "Quality of Service" occurs a lot in the code (and MQTT specification) - this is confusing to adapt to code, we use these forms:
+
+1. For "UpperCamelCase", we use "Qos" - e.g. `SubscriptionGrantedBelowMaximumQos` or `Qos1`
+2. For "SCREAMING_SNAKE_CASE" we use "QOS" - e.g. `QOS_MASK`
+
+This applies to `ReasonCode` names as well, even where these use `QoS` in the spec, e.g. "Granted QoS 1" becomes `GrantedQos1`.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ async fn main() -> Result<(), ClientError> {
 
 The shortening "QoS" for "Quality of Service" occurs a lot in the code (and MQTT specification) - this is confusing to adapt to code, we use these forms:
 
-1. For "UpperCamelCase", we use "Qos" - e.g. `SubscriptionGrantedBelowMaximumQos` or `Qos1`
+1. For "UpperCamelCase", we use "Qos" - e.g. `SubscriptionGrantedBelowMaximumQos` or `Qos1`. This treats "QoS" as an acronym/contraction and so follows the [Rust naming convention](https://rust-lang.github.io/api-guidelines/naming.html) that this counts as one word for capitalisation.
 2. For "SCREAMING_SNAKE_CASE" we use "QOS" - e.g. `QOS_MASK`
 
 This applies to `ReasonCode` names as well, even where these use `QoS` in the spec, e.g. "Granted QoS 1" becomes `GrantedQos1`.

--- a/examples/client_example.rs
+++ b/examples/client_example.rs
@@ -41,13 +41,13 @@ async fn main() -> Result<(), ClientError> {
     let topic_name = "mountain-mqtt-example-topic";
     let retain = false;
 
-    client.subscribe(topic_name, QualityOfService::QoS0).await?;
+    client.subscribe(topic_name, QualityOfService::Qos0).await?;
 
     client
         .publish(
             topic_name,
             "Hello MQTT!".as_bytes(),
-            QualityOfService::QoS0,
+            QualityOfService::Qos0,
             retain,
         )
         .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -263,7 +263,7 @@ where
                 let event = self.client_state.receive(packet)?;
 
                 match event {
-                    ClientStateReceiveEvent::None => None,
+                    ClientStateReceiveEvent::Ack => None,
                     ClientStateReceiveEvent::Publish { publish } => {
                         (self.message_handler)(Message {
                             topic_name: publish.topic_name(),
@@ -271,7 +271,7 @@ where
                         })?;
                         None
                     }
-                    ClientStateReceiveEvent::PublishAndPubAck { publish, puback } => {
+                    ClientStateReceiveEvent::PublishAndPuback { publish, puback } => {
                         (self.message_handler)(Message {
                             topic_name: publish.topic_name(),
                             payload: publish.payload(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -278,11 +278,18 @@ where
                         })?;
                         Some(puback)
                     }
+
+                    // Not an error, no handler for now
                     ClientStateReceiveEvent::SubscriptionGrantedBelowMaximumQoS {
                         granted_qos: _,
                         maximum_qos: _,
                     } => None,
+
+                    // Not an error, no handler for now
                     ClientStateReceiveEvent::PublishedMessageHadNoMatchingSubscribers => None,
+
+                    // Not an error, no handler for now
+                    ClientStateReceiveEvent::NoSubscriptionExisted => None,
 
                     ClientStateReceiveEvent::Disconnect { disconnect } => {
                         return Err(ClientError::Disconnected(*disconnect.reason_code()));

--- a/src/client.rs
+++ b/src/client.rs
@@ -280,7 +280,7 @@ where
                     }
 
                     // Not an error, no handler for now
-                    ClientStateReceiveEvent::SubscriptionGrantedBelowMaximumQoS {
+                    ClientStateReceiveEvent::SubscriptionGrantedBelowMaximumQos {
                         granted_qos: _,
                         maximum_qos: _,
                     } => None,

--- a/src/codec/mqtt_reader.rs
+++ b/src/codec/mqtt_reader.rs
@@ -179,8 +179,8 @@ pub trait MqttReader<'a>: Sized {
         let value = self.get_u8()?;
         match value {
             0 => Ok(ReasonCode::Success),
-            1 => Ok(ReasonCode::GrantedQoS1),
-            2 => Ok(ReasonCode::GrantedQoS2),
+            1 => Ok(ReasonCode::GrantedQos1),
+            2 => Ok(ReasonCode::GrantedQos2),
             4 => Ok(ReasonCode::DisconnectWithWillMessage),
             16 => Ok(ReasonCode::NoMatchingSubscribers),
             17 => Ok(ReasonCode::NoSubscriptionExisted),
@@ -213,7 +213,7 @@ pub trait MqttReader<'a>: Sized {
             152 => Ok(ReasonCode::AdministrativeAction),
             153 => Ok(ReasonCode::PayloadFormatInvalid),
             154 => Ok(ReasonCode::RetainNotSupported),
-            155 => Ok(ReasonCode::QoSNotSupported),
+            155 => Ok(ReasonCode::QosNotSupported),
             156 => Ok(ReasonCode::UseAnotherServer),
             157 => Ok(ReasonCode::ServerMoved),
             158 => Ok(ReasonCode::SharedSubscriptionsNotSupported),
@@ -669,7 +669,7 @@ mod tests {
         let codes = [
             ReasonCode::AdministrativeAction,
             ReasonCode::Banned,
-            ReasonCode::GrantedQoS1,
+            ReasonCode::GrantedQos1,
             ReasonCode::PayloadFormatInvalid,
             ReasonCode::Success,
             ReasonCode::UnspecifiedError,

--- a/src/codec/mqtt_writer.rs
+++ b/src/codec/mqtt_writer.rs
@@ -830,7 +830,7 @@ mod tests {
         let codes = [
             ReasonCode::AdministrativeAction,
             ReasonCode::Banned,
-            ReasonCode::GrantedQoS1,
+            ReasonCode::GrantedQos1,
             ReasonCode::PayloadFormatInvalid,
             ReasonCode::Success,
             ReasonCode::UnspecifiedError,

--- a/src/data/packet_identifier.rs
+++ b/src/data/packet_identifier.rs
@@ -13,9 +13,9 @@ pub enum PublishPacketIdentifier {
 impl PublishPacketIdentifier {
     pub fn qos(&self) -> QualityOfService {
         match self {
-            PublishPacketIdentifier::None => QualityOfService::QoS0,
-            PublishPacketIdentifier::Qos1(_id) => QualityOfService::QoS1,
-            PublishPacketIdentifier::Qos2(_id) => QualityOfService::QoS2,
+            PublishPacketIdentifier::None => QualityOfService::Qos0,
+            PublishPacketIdentifier::Qos1(_id) => QualityOfService::Qos1,
+            PublishPacketIdentifier::Qos2(_id) => QualityOfService::Qos2,
         }
     }
 }

--- a/src/data/packet_type.rs
+++ b/src/data/packet_type.rs
@@ -12,16 +12,16 @@ pub enum PacketType {
     /// Publish message
     /// Client to Server or Server to Client
     Publish = 3,
-    /// Publish acknowledgment (QoS 1)
+    /// Publish acknowledgment (quality of service 1)
     /// Client to Server or Server to Client
     Puback = 4,
-    /// Publish received (QoS 2 delivery part 1)
+    /// Publish received (quality of service 2 delivery part 1)
     /// Client to Server or Server to Client
     Pubrec = 5,
-    /// Publish release (QoS 2 delivery part 2)
+    /// Publish release (quality of service 2 delivery part 2)
     /// Client to Server or Server to Client
     Pubrel = 6,
-    /// Publish complete (QoS 2 delivery part 3)
+    /// Publish complete (quality of service 2 delivery part 3)
     /// Client to Server or Server to Client
     Pubcomp = 7,
     /// Subscribe request

--- a/src/data/property.rs
+++ b/src/data/property.rs
@@ -318,7 +318,7 @@ property_str!(ReasonString, 0x1F);
 property_owned!(ReceiveMaximum, u16, 0x21);
 property_owned!(TopicAliasMaximum, u16, 0x22);
 property_owned!(TopicAlias, u16, 0x23);
-property_owned!(MaximumQoS, u8, 0x24);
+property_owned!(MaximumQos, u8, 0x24);
 property_owned!(RetainAvailable, u8, 0x25);
 property_string_pair!(UserProperty, 0x26);
 property_owned!(MaximumPacketSize, u32, 0x27);
@@ -353,7 +353,7 @@ packet_properties!(
         ReasonString,
         ReceiveMaximum,
         TopicAliasMaximum,
-        MaximumQoS,
+        MaximumQos,
         RetainAvailable,
         UserProperty,
         MaximumPacketSize,

--- a/src/data/quality_of_service.rs
+++ b/src/data/quality_of_service.rs
@@ -3,9 +3,9 @@ use crate::error::PacketReadError;
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum QualityOfService {
-    QoS0 = 0,
-    QoS1 = 1,
-    QoS2 = 2,
+    Qos0 = 0,
+    Qos1 = 1,
+    Qos2 = 2,
 }
 
 impl TryFrom<u8> for QualityOfService {
@@ -13,10 +13,10 @@ impl TryFrom<u8> for QualityOfService {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(QualityOfService::QoS0),
-            1 => Ok(QualityOfService::QoS1),
-            2 => Ok(QualityOfService::QoS2),
-            _ => Err(PacketReadError::InvalidQoSValue),
+            0 => Ok(QualityOfService::Qos0),
+            1 => Ok(QualityOfService::Qos1),
+            2 => Ok(QualityOfService::Qos2),
+            _ => Err(PacketReadError::InvalidQosValue),
         }
     }
 }

--- a/src/data/reason_code.rs
+++ b/src/data/reason_code.rs
@@ -100,8 +100,8 @@ macro_rules! packet_reason_codes {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ReasonCode {
     Success = 0,
-    GrantedQoS1 = 1,
-    GrantedQoS2 = 2,
+    GrantedQos1 = 1,
+    GrantedQos2 = 2,
     DisconnectWithWillMessage = 4,
     NoMatchingSubscribers = 16,
     NoSubscriptionExisted = 17,
@@ -134,7 +134,7 @@ pub enum ReasonCode {
     AdministrativeAction = 152,
     PayloadFormatInvalid = 153,
     RetainNotSupported = 154,
-    QoSNotSupported = 155,
+    QosNotSupported = 155,
     UseAnotherServer = 156,
     ServerMoved = 157,
     SharedSubscriptionsNotSupported = 158,
@@ -171,7 +171,7 @@ packet_reason_codes!(
         QuotaExceeded,
         PayloadFormatInvalid,
         RetainNotSupported,
-        QoSNotSupported,
+        QosNotSupported,
         UseAnotherServer,
         ServerMoved,
         ConnectionRateExceeded
@@ -202,7 +202,7 @@ packet_reason_codes!(
         AdministrativeAction,
         PayloadFormatInvalid,
         RetainNotSupported,
-        QoSNotSupported,
+        QosNotSupported,
         UseAnotherServer,
         ServerMoved,
         SharedSubscriptionsNotSupported,
@@ -234,8 +234,8 @@ packet_reason_codes!(
     SubscribeReasonCode,
     [
         Success,
-        GrantedQoS1,
-        GrantedQoS2,
+        GrantedQos1,
+        GrantedQos2,
         UnspecifiedError,
         ImplementationSpecificError,
         NotAuthorized,

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,7 @@ pub enum PacketReadError {
 
     /// Data contained an encoded [QualityOfService] value which was not a recognised value
     /// (Malformed Packet)
-    InvalidQoSValue,
+    InvalidQosValue,
 
     /// A Connect packet was decoded which did not contain the expected protocol name (MQTT) and version (5)
     /// This can be returned to clients, but it is also acceptable to simply close the network connection,
@@ -108,8 +108,8 @@ pub enum PacketReadError {
     /// to a [Unsubscribe] with at least one subscription request [MQTT-3.10.3-2]
     UnsubackWithoutValidReasonCode,
 
-    // If a connect packet has no will specified, it must also have the will QoS bits as 0 [MQTT-3.1.2-11]
-    WillQoSSpecifiedWithoutWill,
+    // If a connect packet has no will specified, it must also have the will quality of service bits as 0 [MQTT-3.1.2-11]
+    WillQosSpecifiedWithoutWill,
 
     // If a connect packet has no will specified, it must also have the will Retain bit as 0 [MQTT-3.1.2-13]
     WillRetainSpecifiedWithoutWill,
@@ -137,7 +137,7 @@ impl Display for PacketReadError {
             Self::UnknownReasonCode => write!(f, "UnknownReasonCode"),
             Self::InvalidBooleanValue => write!(f, "InvalidBooleanValue"),
             Self::TooManyProperties => write!(f, "TooManyProperties"),
-            Self::InvalidQoSValue => write!(f, "InvalidQoSValue"),
+            Self::InvalidQosValue => write!(f, "InvalidQosValue"),
             Self::UnsupportedProtocolVersion => write!(f, "UnsupportedProtocolVersion"),
             Self::TooManyRequests => write!(f, "TooManyRequests"),
             Self::InvalidPacketType => write!(f, "InvalidPacketType"),
@@ -155,7 +155,7 @@ impl Display for PacketReadError {
                 write!(f, "UnsubscribeWithoutValidSubscriptionRequest")
             }
             Self::UnsubackWithoutValidReasonCode => write!(f, "UnsubackWithoutValidReasonCode"),
-            Self::WillQoSSpecifiedWithoutWill => write!(f, "WillQoSSpecifiedWithoutWill"),
+            Self::WillQosSpecifiedWithoutWill => write!(f, "WillQosSpecifiedWithoutWill"),
             Self::WillRetainSpecifiedWithoutWill => write!(f, "WillRetainSpecifiedWithoutWill"),
             Self::SubscriptionOptionsReservedBitsNonZero => {
                 write!(f, "ReservedBitsSetInSubscriptionOptions")

--- a/src/packet_client.rs
+++ b/src/packet_client.rs
@@ -202,10 +202,10 @@ mod tests {
     ];
 
     fn example_subscribe_packet<'a>() -> Subscribe<'a, 16, 16> {
-        let primary_request = SubscriptionRequest::new("test/topic", QualityOfService::QoS0);
+        let primary_request = SubscriptionRequest::new("test/topic", QualityOfService::Qos0);
         let mut additional_requests = Vec::new();
         additional_requests
-            .push(SubscriptionRequest::new("hehe/#", QualityOfService::QoS1))
+            .push(SubscriptionRequest::new("hehe/#", QualityOfService::Qos1))
             .unwrap();
         let mut properties = Vec::new();
         properties

--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -211,9 +211,9 @@ impl<'a, const PROPERTIES_N: usize> PacketRead<'a> for Connect<'a, PROPERTIES_N>
         } else {
             // If will flag is not set, we must have the following values, otherwise
             // this is an error
-            // QoS bits as 0 [MQTT-3.1.2-11]
+            // Quality of service bits as 0 [MQTT-3.1.2-11]
             if will_qos_value != 0 {
-                return Err(PacketReadError::WillQoSSpecifiedWithoutWill);
+                return Err(PacketReadError::WillQosSpecifiedWithoutWill);
             }
             // Retain bit as 0 [MQTT-3.1.2-13]
             if will_retain {
@@ -297,7 +297,7 @@ mod tests {
             .push(WillProperty::MessageExpiryInterval(12345.into()))
             .unwrap();
         let will = Will {
-            qos: QualityOfService::QoS2,
+            qos: QualityOfService::Qos2,
             retain: true,
             topic_name: "wt",
             payload: &[1, 2, 3],
@@ -319,7 +319,7 @@ mod tests {
         0x1F,
         // protocol name and version
         0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
-        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will QoS (2),
+        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will qos (2),
         // bit 5 will retain, bit 6 password, bit 7 username
         0b0011_0110,
         // Keep alive
@@ -349,7 +349,7 @@ mod tests {
         0x1F,
         // protocol name and version
         0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
-        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will QoS (3 - invalid value),
+        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will qos (3 - invalid value),
         // bit 5 will retain, bit 6 password, bit 7 username
         0b0011_1110,
         // Keep alive
@@ -377,7 +377,7 @@ mod tests {
             .push(WillProperty::MessageExpiryInterval(12345.into()))
             .unwrap();
         let will = Will {
-            qos: QualityOfService::QoS1,
+            qos: QualityOfService::Qos1,
             retain: false,
             topic_name: "tw",
             payload: &[3, 2, 1],
@@ -407,7 +407,7 @@ mod tests {
         0x2A,
         // protocol name and version
         0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
-        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will QoS (1),
+        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 has will, bit 3+4 will qos (1),
         // bit 5 will retain, bit 6 password, bit 7 username
         0b1100_1100,
         // Keep alive
@@ -500,7 +500,7 @@ mod tests {
         0x1F,
         // protocol name and version
         0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
-        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 clear so no will, bit 3+4 will QoS (2),
+        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 clear so no will, bit 3+4 will qos (2),
         // bit 5 will retain is clear, bit 6 password, bit 7 username
         0b0001_1010,
         // Keep alive
@@ -530,7 +530,7 @@ mod tests {
         0x1F,
         // protocol name and version
         0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
-        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 clear so no will, bit 3+4 will QoS (0),
+        // Connect flags, bit 0 reserved as 0, bit 1 clean start, bit 2 clear so no will, bit 3+4 will qos (0),
         // bit 5 will retain is set, bit 6 password, bit 7 username
         0b0010_0010,
         // Keep alive
@@ -598,7 +598,7 @@ mod tests {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_WILL_QOS_WITHOUT_WILL_FLAG);
         assert_eq!(
             r.get::<Connect<'_, 16>>(),
-            Err(PacketReadError::WillQoSSpecifiedWithoutWill)
+            Err(PacketReadError::WillQosSpecifiedWithoutWill)
         );
     }
 
@@ -625,7 +625,7 @@ mod tests {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_WILL_INVALID_QOS);
         assert_eq!(
             r.get::<Connect<'_, 16>>(),
-            Err(PacketReadError::InvalidQoSValue)
+            Err(PacketReadError::InvalidQosValue)
         );
     }
 

--- a/src/packets/publish.rs
+++ b/src/packets/publish.rs
@@ -69,9 +69,9 @@ impl<'a, const PROPERTIES_N: usize> Publish<'a, PROPERTIES_N> {
 
     pub fn qos(&self) -> QualityOfService {
         match &self.publish_packet_identifier {
-            PublishPacketIdentifier::None => QualityOfService::QoS0,
-            PublishPacketIdentifier::Qos1(_) => QualityOfService::QoS1,
-            PublishPacketIdentifier::Qos2(_) => QualityOfService::QoS2,
+            PublishPacketIdentifier::None => QualityOfService::Qos0,
+            PublishPacketIdentifier::Qos1(_) => QualityOfService::Qos1,
+            PublishPacketIdentifier::Qos2(_) => QualityOfService::Qos2,
         }
     }
 
@@ -111,7 +111,7 @@ impl<const PROPERTIES_N: usize> PacketWrite for Publish<'_, PROPERTIES_N> {
         // Write the fixed parts of the variable header
         writer.put_str(self.topic_name)?;
         match &self.publish_packet_identifier {
-            PublishPacketIdentifier::None => {} // QoS0, no packet identifier
+            PublishPacketIdentifier::None => {} // Qos0, no packet identifier
             PublishPacketIdentifier::Qos1(id) => writer.put_u16(id.0)?,
             PublishPacketIdentifier::Qos2(id) => writer.put_u16(id.0)?,
         }
@@ -148,10 +148,10 @@ impl<'a, const PROPERTIES_N: usize> PacketRead<'a> for Publish<'a, PROPERTIES_N>
 
         let topic_name = reader.get_str()?;
         let packet_identifier = match qos_value {
-            0 => PublishPacketIdentifier::None, // QoS0, no packet identifier
+            0 => PublishPacketIdentifier::None, // Qos0, no packet identifier
             1 => PublishPacketIdentifier::Qos1(PacketIdentifier(reader.get_u16()?)),
             2 => PublishPacketIdentifier::Qos1(PacketIdentifier(reader.get_u16()?)),
-            _ => return Err(PacketReadError::InvalidQoSValue),
+            _ => return Err(PacketReadError::InvalidQosValue),
         };
 
         let mut properties = Vec::new();

--- a/src/packets/subscribe.rs
+++ b/src/packets/subscribe.rs
@@ -155,7 +155,7 @@ mod tests {
     pub const SUBSCRIPTION_OPTIONS_CASES: [(SubscriptionOptions, u8); 7] = [
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS0,
+                maximum_qos: QualityOfService::Qos0,
                 no_local: false,
                 retain_as_published: false,
                 retain_handling: RetainHandling::SendOnSubscribe,
@@ -164,7 +164,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS1,
+                maximum_qos: QualityOfService::Qos1,
                 no_local: false,
                 retain_as_published: false,
                 retain_handling: RetainHandling::SendOnSubscribe,
@@ -173,7 +173,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS2,
+                maximum_qos: QualityOfService::Qos2,
                 no_local: false,
                 retain_as_published: false,
                 retain_handling: RetainHandling::SendOnSubscribe,
@@ -182,7 +182,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS0,
+                maximum_qos: QualityOfService::Qos0,
                 no_local: true,
                 retain_as_published: false,
                 retain_handling: RetainHandling::SendOnSubscribe,
@@ -191,7 +191,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS0,
+                maximum_qos: QualityOfService::Qos0,
                 no_local: false,
                 retain_as_published: true,
                 retain_handling: RetainHandling::SendOnSubscribe,
@@ -200,7 +200,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS0,
+                maximum_qos: QualityOfService::Qos0,
                 no_local: false,
                 retain_as_published: false,
                 retain_handling: RetainHandling::SendOnNewSubscribe,
@@ -209,7 +209,7 @@ mod tests {
         ),
         (
             SubscriptionOptions {
-                maximum_qos: QualityOfService::QoS0,
+                maximum_qos: QualityOfService::Qos0,
                 no_local: false,
                 retain_as_published: false,
                 retain_handling: RetainHandling::DoNotSend,
@@ -292,10 +292,10 @@ mod tests {
     }
 
     fn example_packet<'a>() -> Subscribe<'a, 1, 2> {
-        let first_request = SubscriptionRequest::new("test/topic", QualityOfService::QoS0);
+        let first_request = SubscriptionRequest::new("test/topic", QualityOfService::Qos0);
         let mut other_requests = Vec::new();
         other_requests
-            .push(SubscriptionRequest::new("hehe/#", QualityOfService::QoS1))
+            .push(SubscriptionRequest::new("hehe/#", QualityOfService::Qos1))
             .unwrap();
         let mut properties = Vec::new();
         properties

--- a/tests/client_no_queue_to_external_broker.rs
+++ b/tests/client_no_queue_to_external_broker.rs
@@ -41,12 +41,12 @@ async fn client_connect_subscribe_and_publish() {
     client.connect(connect).await.unwrap();
 
     client
-        .subscribe(TOPIC_NAME, QualityOfService::QoS0)
+        .subscribe(TOPIC_NAME, QualityOfService::Qos0)
         .await
         .unwrap();
 
     client
-        .publish(TOPIC_NAME, PAYLOAD, QualityOfService::QoS0, false)
+        .publish(TOPIC_NAME, PAYLOAD, QualityOfService::Qos0, false)
         .await
         .unwrap();
 
@@ -57,7 +57,7 @@ async fn client_connect_subscribe_and_publish() {
 
     // Send another message
     client
-        .publish(TOPIC_NAME, PAYLOAD2, QualityOfService::QoS0, false)
+        .publish(TOPIC_NAME, PAYLOAD2, QualityOfService::Qos0, false)
         .await
         .unwrap();
     let received = client.poll(true).await.unwrap();

--- a/tests/packet_client_to_external_broker.rs
+++ b/tests/packet_client_to_external_broker.rs
@@ -101,7 +101,7 @@ async fn connect_subscribe_and_publish() {
     let mut buf = [0; 1024];
     let mut client = tokio_localhost_client_connected(CLIENT_ID, &mut buf).await;
 
-    let primary_request = SubscriptionRequest::new(TOPIC_NAME, QualityOfService::QoS0);
+    let primary_request = SubscriptionRequest::new(TOPIC_NAME, QualityOfService::Qos0);
     let subscribe: Subscribe<'_, 0, 0> =
         Subscribe::new(PACKET_IDENTIFIER, primary_request, Vec::new(), Vec::new());
     client.send(subscribe).await.unwrap();


### PR DESCRIPTION
Add event for unsubscribe reporting that there no subscription existed.
Use "Qos" for UpperCamelCase version of "QoS".
Change client event "None" to "Ack" to better reflect what it does.
Fix some typo case errors.