### PR TITLE
Use a new `ConnectionSettings` struct to connect `Client`, instead of a `Publish` packet, so that the client can fill out properties and lower-level settings as needed, based on higher-level settings from user.

### DIFF
--- a/examples/client_example.rs
+++ b/examples/client_example.rs
@@ -1,7 +1,7 @@
 use mountain_mqtt::{
-    client::{Client, ClientError},
+    client::{Client, ClientError, ConnectionSettings},
     data::quality_of_service::QualityOfService,
-    packets::{connect::Connect, publish::ApplicationMessage},
+    packets::publish::ApplicationMessage,
     tokio::client_tcp,
 };
 use tokio::sync::mpsc;
@@ -32,7 +32,7 @@ async fn main() -> Result<(), ClientError> {
         |message: ApplicationMessage<'_, 16>| {
             message_tx
                 .try_send((message.topic_name.to_owned(), message.payload.to_vec()))
-                .map_err(|_| ClientError::MessageHandlerError)
+                .map_err(|_| ClientError::MessageHandler)
         },
     )
     .await;
@@ -41,7 +41,9 @@ async fn main() -> Result<(), ClientError> {
     // `unauthenticated` uses default settings and no username/password, see `Connect::new` for
     // available options (keep alive, will, authentication, additional properties etc.)
     client
-        .connect(Connect::unauthenticated("mountain-mqtt-example-client-id"))
+        .connect(ConnectionSettings::unauthenticated(
+            "mountain-mqtt-example-client-id",
+        ))
         .await?;
 
     let topic_name = "mountain-mqtt-example-topic";

--- a/tests/client_no_queue_to_external_broker.rs
+++ b/tests/client_no_queue_to_external_broker.rs
@@ -1,8 +1,7 @@
-use heapless::Vec;
 use mountain_mqtt::{
-    client::{Client, ClientNoQueue},
+    client::{Client, ClientNoQueue, ConnectionSettings},
     data::quality_of_service::QualityOfService,
-    packets::{connect::Connect, publish::ApplicationMessage},
+    packets::publish::ApplicationMessage,
     tokio::{ConnectionTcpStream, TokioDelay},
 };
 use tokio::{net::TcpStream, sync::mpsc};
@@ -43,8 +42,10 @@ async fn client_connect_subscribe_and_publish() {
     const PAYLOAD2: &[u8] =
         "mountain-mqtt-test-payload2-client_connect_subscribe_and_publish".as_bytes();
 
-    let connect: Connect<'_, 0> = Connect::new(60, None, None, CLIENT_ID, true, None, Vec::new());
-    client.connect(connect).await.unwrap();
+    client
+        .connect(ConnectionSettings::unauthenticated(CLIENT_ID))
+        .await
+        .unwrap();
 
     client
         .subscribe(TOPIC_NAME, QualityOfService::Qos0)


### PR DESCRIPTION
ClientNoQueue now sends a topic alias maximum property of 0, to prevent server from using topic aliases, and produces a client error if it sees an empty topic name indicating use of a topic alias.