### PR TITLE
Make `Client` event_handler callback use a trait, with an async function, making it more flexible

### DIFF
--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -7,7 +7,7 @@ use tokio::{
 };
 
 use crate::{
-    client::{ClientNoQueue, ClientReceivedEvent, Delay, EventHandlerError},
+    client::{ClientNoQueue, Delay, EventHandler},
     error::{PacketReadError, PacketWriteError},
     packet_client::Connection,
 };
@@ -98,7 +98,7 @@ pub async fn client_tcp<F, const P: usize>(
     event_handler: F,
 ) -> ClientNoQueue<'_, ConnectionTcpStream, TokioDelay, F, P>
 where
-    F: Fn(ClientReceivedEvent<P>) -> Result<(), EventHandlerError>,
+    F: EventHandler<P>,
 {
     let addr = core::net::SocketAddr::new(ip.into(), port);
     let tcp_stream = TcpStream::connect(addr).await.unwrap();


### PR DESCRIPTION
Ad a new `Closed` variant for `EventHandlerError`