### PR TITLE
defmt as standalone feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio-test = { version = "0.4.2" }
 [features]
 default = ["tokio", "embedded-io-async", "embedded-hal-async", "defmt"]
 tokio = ["dep:tokio", "std"]
+defmt = ["dep:defmt"]
 embedded-io-async = ["dep:embedded-io-async", "dep:embedded-io"]
 embedded-hal-async = ["dep:embedded-hal-async"]
 std = []


### PR DESCRIPTION
Adds `defmt` to enable defmt without enabling tokio at the same time