### PR TITLE
Make Will fields public

### DIFF
--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -12,11 +12,11 @@ use heapless::Vec;
 
 #[derive(Debug, PartialEq)]
 pub struct Will<'a, const P: usize> {
-    qos: QualityOfService,
-    retain: bool,
-    topic_name: &'a str,
-    payload: &'a [u8],
-    properties: Vec<WillProperty<'a>, P>,
+    pub qos: QualityOfService,
+    pub retain: bool,
+    pub topic_name: &'a str,
+    pub payload: &'a [u8],
+    pub properties: Vec<WillProperty<'a>, P>,
 }
 
 const CLEAN_START_BIT: u8 = 1 << 1;


### PR DESCRIPTION
When we want to initiate a connection with a last will, we can't since Will have no constructor and it's field are private. The test work since they are in the same file (I think, not a veteran of rust :P).
```rust
let result_connection = client
    .connect(Connect::<0>::new(
        60,
        Some(env!("TOKEN")),
        Some(&[0]),
        env!("ID"),
        true,
        Some(
            (Will {
                qos: mountain_mqtt::data::quality_of_service::QualityOfService::QoS0,
                retain: false,
                topic_name: "wt",
                payload: &[0,1,2],
                properties: Vec::new(),
            }),
        ),
        Vec::new(),
    ))
    .await;
```