### PR TITLE
Allow for using a `Will` with `Client`

### DIFF
--- a/src/client_state.rs
+++ b/src/client_state.rs
@@ -216,8 +216,10 @@ pub trait ClientState {
 
     /// Update state based on a packet used to connect to server
     /// Call this after connect packet has been successfully sent.
-    fn connect<const P: usize>(&mut self, connect: &Connect<'_, P>)
-        -> Result<(), ClientStateError>;
+    fn connect<const P: usize, const W: usize>(
+        &mut self,
+        connect: &Connect<'_, P, W>,
+    ) -> Result<(), ClientStateError>;
 
     /// Produce a packet to disconnect from server, update state
     fn disconnect<'b>(&mut self) -> Result<Disconnect<'b, 0>, ClientStateError>;
@@ -230,9 +232,9 @@ pub trait ClientState {
     /// action by the caller occurs, a [ClientStateReceiveEvent] is returned.
     /// Errors indicate an invalid packet was received, message_target errored,
     /// or the received packet was unexpected based on our state
-    fn receive<'a, 'b, const P: usize, const S: usize>(
+    fn receive<'a, 'b, const P: usize, const W: usize, const S: usize>(
         &mut self,
-        packet: PacketGeneric<'a, P, S>,
+        packet: PacketGeneric<'a, P, W, S>,
     ) -> Result<ClientStateReceiveEvent<'a, 'b, P>, ClientStateError>;
 
     /// Produce a packet to subscribe to a topic by name, update state
@@ -356,9 +358,9 @@ impl ClientState for ClientStateNoQueue {
         }
     }
 
-    fn connect<const P: usize>(
+    fn connect<const P: usize, const W: usize>(
         &mut self,
-        connect: &Connect<'_, P>,
+        connect: &Connect<'_, P, W>,
     ) -> Result<(), ClientStateError> {
         match self {
             ClientStateNoQueue::Idle => {
@@ -493,9 +495,9 @@ impl ClientState for ClientStateNoQueue {
         }
     }
 
-    fn receive<'a, 'b, const P: usize, const S: usize>(
+    fn receive<'a, 'b, const P: usize, const W: usize, const S: usize>(
         &mut self,
-        packet: PacketGeneric<'a, P, S>,
+        packet: PacketGeneric<'a, P, W, S>,
     ) -> Result<ClientStateReceiveEvent<'a, 'b, P>, ClientStateError> {
         match self {
             // If we are connecting, we only expect a Connack packet

--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -46,18 +46,18 @@ const PASSWORD_PRESENT_BIT: u8 = 1 << 6;
 const USERNAME_PRESENT_BIT: u8 = 1 << 7;
 
 #[derive(Debug, PartialEq)]
-pub struct Connect<'a, const P: usize> {
+pub struct Connect<'a, const P: usize, const W: usize> {
     keep_alive: u16,
     username: Option<&'a str>,
     password: Option<&'a [u8]>,
     client_id: &'a str,
     clean_start: bool,
-    will: Option<Will<'a, P>>,
+    will: Option<Will<'a, W>>,
     pub properties: Vec<ConnectProperty<'a>, P>,
 }
 
-impl<'a> Connect<'a, 0> {
-    pub fn unauthenticated(client_id: &'a str) -> Connect<'a, 0> {
+impl<'a> Connect<'a, 0, 0> {
+    pub fn unauthenticated(client_id: &'a str) -> Connect<'a, 0, 0> {
         Self {
             keep_alive: KEEP_ALIVE_DEFAULT,
             username: None,
@@ -70,14 +70,14 @@ impl<'a> Connect<'a, 0> {
     }
 }
 
-impl<'a, const P: usize> Connect<'a, P> {
+impl<'a, const P: usize, const W: usize> Connect<'a, P, W> {
     pub fn new(
         keep_alive: u16,
         username: Option<&'a str>,
         password: Option<&'a [u8]>,
         client_id: &'a str,
         clean_start: bool,
-        will: Option<Will<'a, P>>,
+        will: Option<Will<'a, W>>,
         properties: Vec<ConnectProperty<'a>, P>,
     ) -> Self {
         Self {
@@ -122,16 +122,16 @@ impl<'a, const P: usize> Connect<'a, P> {
     }
 }
 
-impl<const P: usize> Packet for Connect<'_, P> {
+impl<const P: usize, const W: usize> Packet for Connect<'_, P, W> {
     fn packet_type(&self) -> PacketType {
         PacketType::Connect
     }
 }
 
-impl<const P: usize> PacketWrite for Connect<'_, P> {
-    fn put_variable_header_and_payload<'w, W: MqttWriter<'w>>(
+impl<const P: usize, const W: usize> PacketWrite for Connect<'_, P, W> {
+    fn put_variable_header_and_payload<'w, Writer: MqttWriter<'w>>(
         &self,
-        writer: &mut W,
+        writer: &mut Writer,
     ) -> mqtt_writer::Result<()> {
         // Variable header:
 
@@ -169,7 +169,7 @@ impl<const P: usize> PacketWrite for Connect<'_, P> {
     }
 }
 
-impl<'a, const P: usize> PacketRead<'a> for Connect<'a, P> {
+impl<'a, const P: usize, const W: usize> PacketRead<'a> for Connect<'a, P, W> {
     fn get_variable_header_and_payload<R: crate::codec::mqtt_reader::MqttReader<'a>>(
         reader: &mut R,
         _first_header_byte: u8,
@@ -279,7 +279,7 @@ mod tests {
 
     use super::*;
 
-    fn example_packet<'a>() -> Connect<'a, 1> {
+    fn example_packet<'a>() -> Connect<'a, 1, 0> {
         let mut packet = Connect::new(60, None, None, "", true, None, Vec::new());
         packet
             .properties
@@ -309,7 +309,7 @@ mod tests {
         0x00, 0x3c, 0x03, 0x21, 0x00, 0x14, 0x00, 0x00,
     ];
 
-    fn example_packet_will<'a>() -> Connect<'a, 1> {
+    fn example_packet_will<'a>() -> Connect<'a, 1, 1> {
         let mut will_properties = Vec::new();
         will_properties
             .push(WillProperty::MessageExpiryInterval(12345.into()))
@@ -389,7 +389,7 @@ mod tests {
         0x00, 0x03, 0x01, 0x02, 0x03,
     ];
 
-    fn example_packet_will2<'a>() -> Connect<'a, 1> {
+    fn example_packet_will2<'a>() -> Connect<'a, 1, 1> {
         let mut will_properties = Vec::new();
         will_properties
             .push(WillProperty::MessageExpiryInterval(12345.into()))
@@ -451,7 +451,7 @@ mod tests {
         0x00, 0x02, 0x42,0x84
     ];
 
-    fn example_packet_username<'a>() -> Connect<'a, 1> {
+    fn example_packet_username<'a>() -> Connect<'a, 1, 0> {
         let mut packet = Connect::new(60, Some("user"), None, "", true, None, Vec::new());
         packet
             .properties
@@ -465,7 +465,7 @@ mod tests {
         0x14, 0x00, 0x00, 0x00, 0x04, 0x75, 0x73, 0x65, 0x72,
     ];
 
-    fn example_packet_username_password<'a>() -> Connect<'a, 1> {
+    fn example_packet_username_password<'a>() -> Connect<'a, 1, 0> {
         let mut packet = Connect::new(
             60,
             Some("user"),
@@ -487,7 +487,7 @@ mod tests {
         0x14, 0x00, 0x00, 0x00, 0x04, 0x75, 0x73, 0x65, 0x72, 0x00, 0x04, 0x70, 0x61, 0x73, 0x73,
     ];
 
-    fn example_packet_clientid_username_password<'a>() -> Connect<'a, 1> {
+    fn example_packet_clientid_username_password<'a>() -> Connect<'a, 1, 0> {
         let mut packet = Connect::new(
             60,
             Some("user"),
@@ -570,12 +570,18 @@ mod tests {
         0x00, 0x03, 0x01, 0x02, 0x03,
     ];
 
-    fn encode_decode_and_check<const P: usize>(packet: &Connect<'_, P>, encoded: &[u8]) {
+    fn encode_decode_and_check<const P: usize, const W: usize>(
+        packet: &Connect<'_, P, W>,
+        encoded: &[u8],
+    ) {
         encode_and_check(packet, encoded);
         decode_and_check(packet, encoded);
     }
 
-    fn encode_and_check<const P: usize>(packet: &Connect<'_, P>, encoded: &[u8]) {
+    fn encode_and_check<const P: usize, const W: usize>(
+        packet: &Connect<'_, P, W>,
+        encoded: &[u8],
+    ) {
         let mut buf = [0u8; 1024];
         let len = {
             let mut r = MqttBufWriter::new(&mut buf[0..encoded.len()]);
@@ -585,9 +591,12 @@ mod tests {
         assert_eq!(&buf[0..len], encoded);
     }
 
-    fn decode_and_check<const P: usize>(packet: &Connect<'_, P>, encoded: &[u8]) {
+    fn decode_and_check<const P: usize, const W: usize>(
+        packet: &Connect<'_, P, W>,
+        encoded: &[u8],
+    ) {
         let mut r = MqttBufReader::new(encoded);
-        let read_packet: Connect<'_, P> = r.get().unwrap();
+        let read_packet: Connect<'_, P, W> = r.get().unwrap();
         assert_eq!(&read_packet, packet);
         assert_eq!(r.position(), encoded.len());
         assert_eq!(r.remaining(), 0);
@@ -597,7 +606,7 @@ mod tests {
     fn error_on_decoding_data_with_incorrect_packet_length() {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_INCORRECT_PACKET_LENGTH);
         assert_eq!(
-            r.get::<Connect<'_, 16>>(),
+            r.get::<Connect<'_, 16, 16>>(),
             Err(PacketReadError::IncorrectPacketLength)
         );
     }
@@ -606,7 +615,7 @@ mod tests {
     fn error_on_decoding_data_with_will_qos_not_zero_but_no_will_flag() {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_WILL_QOS_WITHOUT_WILL_FLAG);
         assert_eq!(
-            r.get::<Connect<'_, 16>>(),
+            r.get::<Connect<'_, 16, 16>>(),
             Err(PacketReadError::WillQosSpecifiedWithoutWill)
         );
     }
@@ -615,7 +624,7 @@ mod tests {
     fn error_on_decoding_data_with_will_retain_set_but_no_will_flag() {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_WILL_RETAIN_WITHOUT_WILL_FLAG);
         assert_eq!(
-            r.get::<Connect<'_, 16>>(),
+            r.get::<Connect<'_, 16, 16>>(),
             Err(PacketReadError::WillRetainSpecifiedWithoutWill)
         );
     }
@@ -624,7 +633,7 @@ mod tests {
     fn error_on_decoding_invalid_connect_flags_with_bit0_set() {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_INVALID_CONNECT_FLAGS_BIT0_SET);
         assert_eq!(
-            r.get::<Connect<'_, 16>>(),
+            r.get::<Connect<'_, 16, 16>>(),
             Err(PacketReadError::InvalidConnectFlags)
         );
     }
@@ -633,7 +642,7 @@ mod tests {
     fn error_on_decoding_invalid_connect_flags_with_invalid_will_qos() {
         let mut r = MqttBufReader::new(&EXAMPLE_DATA_WILL_INVALID_QOS);
         assert_eq!(
-            r.get::<Connect<'_, 16>>(),
+            r.get::<Connect<'_, 16, 16>>(),
             Err(PacketReadError::InvalidQosValue)
         );
     }

--- a/src/packets/packet_generic.rs
+++ b/src/packets/packet_generic.rs
@@ -27,11 +27,12 @@ use super::{
 /// Allows for e.g. decoding data of an unknown packet type, we can
 /// then match to handle the different cases.
 /// `P` is the maximum number of properties in a packet.
+/// `W` is the maximum number of properties in a will packet.
 /// `S` is the maximum number of _additional_ subscription requests
 /// after the mandatory request.
 #[derive(Debug, PartialEq)]
-pub enum PacketGeneric<'a, const P: usize, const S: usize> {
-    Connect(Connect<'a, P>),
+pub enum PacketGeneric<'a, const P: usize, const W: usize, const S: usize> {
+    Connect(Connect<'a, P, W>),
     Connack(Connack<'a, P>),
     Publish(Publish<'a, P>),
     Puback(Puback<'a, P>),
@@ -48,7 +49,7 @@ pub enum PacketGeneric<'a, const P: usize, const S: usize> {
     Auth(Auth<'a, P>),
 }
 
-impl<'a, const P: usize, const S: usize> Read<'a> for PacketGeneric<'a, P, S> {
+impl<'a, const P: usize, const W: usize, const S: usize> Read<'a> for PacketGeneric<'a, P, W, S> {
     fn read<R: crate::codec::mqtt_reader::MqttReader<'a>>(
         reader: &mut R,
     ) -> mqtt_reader::Result<Self>
@@ -150,7 +151,7 @@ impl<'a, const P: usize, const S: usize> Read<'a> for PacketGeneric<'a, P, S> {
     }
 }
 
-impl<const P: usize, const S: usize> Packet for PacketGeneric<'_, P, S> {
+impl<const P: usize, const W: usize, const S: usize> Packet for PacketGeneric<'_, P, W, S> {
     fn packet_type(&self) -> PacketType {
         match self {
             PacketGeneric::Connect(_) => PacketType::Connect,

--- a/tests/connection_with_will.rs
+++ b/tests/connection_with_will.rs
@@ -3,7 +3,7 @@ use mountain_mqtt::packets::connect::{Connect, Will};
 
 #[test]
 fn create_connect_packet_with_will() {
-    Connect::<0>::new(
+    Connect::<0, 0>::new(
         60,
         Some("user"),
         Some("password".as_bytes()),

--- a/tests/packet_client_to_external_broker.rs
+++ b/tests/packet_client_to_external_broker.rs
@@ -48,11 +48,12 @@ async fn tokio_localhost_client_connected<'a>(
 ) -> PacketClient<'a, ConnectionTcpStream> {
     let mut client = tokio_localhost_client(buf).await;
 
-    let connect: Connect<'_, 0> = Connect::new(120, None, None, client_id, true, None, Vec::new());
+    let connect: Connect<'_, 0, 0> =
+        Connect::new(120, None, None, client_id, true, None, Vec::new());
     client.send(connect).await.unwrap();
 
     {
-        let maybe_connack: PacketGeneric<'_, 16, 16> = client.receive().await.unwrap();
+        let maybe_connack: PacketGeneric<'_, 16, 16, 16> = client.receive().await.unwrap();
 
         if let PacketGeneric::Connack(connack) = maybe_connack {
             assert!(!connack.session_present());
@@ -106,7 +107,7 @@ async fn connect_subscribe_and_publish() {
         Subscribe::new(PACKET_IDENTIFIER, primary_request, Vec::new(), Vec::new());
     client.send(subscribe).await.unwrap();
     {
-        let maybe_suback: PacketGeneric<'_, 16, 16> = client.receive().await.unwrap();
+        let maybe_suback: PacketGeneric<'_, 16, 16, 16> = client.receive().await.unwrap();
         assert_eq!(
             maybe_suback,
             PacketGeneric::Suback(Suback::new(
@@ -129,7 +130,7 @@ async fn connect_subscribe_and_publish() {
     client.send(publish).await.unwrap();
 
     {
-        let maybe_publish: PacketGeneric<'_, 16, 16> = client.receive().await.unwrap();
+        let maybe_publish: PacketGeneric<'_, 16, 16, 16> = client.receive().await.unwrap();
 
         assert_eq!(
             maybe_publish,
@@ -148,7 +149,7 @@ async fn connect_subscribe_and_publish() {
         Unsubscribe::new(PACKET_IDENTIFIER, TOPIC_NAME, Vec::new(), Vec::new());
     client.send(unsubscribe).await.unwrap();
     {
-        let maybe_unsuback: PacketGeneric<'_, 16, 16> = client.receive().await.unwrap();
+        let maybe_unsuback: PacketGeneric<'_, 16, 16, 16> = client.receive().await.unwrap();
 
         assert_eq!(
             maybe_unsuback,


### PR DESCRIPTION
Add a type parameter for the maximum number of properties in the `Will` contained in a `Connect` packet, and add a new `Client` connect method with an optional `Will`.

Fix #32