### PR TITLE
Move `FromApplicationMessage` into main crate

### DIFF
--- a/embassy-example-rp2040w/src/event.rs
+++ b/embassy-example-rp2040w/src/event.rs
@@ -1,5 +1,7 @@
-use mountain_mqtt::{client::EventHandlerError, packets::publish::ApplicationMessage};
-use mountain_mqtt_embassy::mqtt_manager::FromApplicationMessage;
+use mountain_mqtt::{
+    client::{EventHandlerError, FromApplicationMessage},
+    packets::publish::ApplicationMessage,
+};
 
 pub const TOPIC_LED: &str = "embassy-example-rp2040w-led";
 

--- a/embassy-poll-example-rp2040w/src/event.rs
+++ b/embassy-poll-example-rp2040w/src/event.rs
@@ -1,5 +1,7 @@
-use mountain_mqtt::{client::EventHandlerError, packets::publish::ApplicationMessage};
-use mountain_mqtt_embassy::mqtt_manager::FromApplicationMessage;
+use mountain_mqtt::{
+    client::{EventHandlerError, FromApplicationMessage},
+    packets::publish::ApplicationMessage,
+};
 
 pub const TOPIC_LED: &str = "embassy-example-rp2040w-led";
 

--- a/embassy-poll-example-rp2040w/src/mqtt.rs
+++ b/embassy-poll-example-rp2040w/src/mqtt.rs
@@ -9,11 +9,10 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, Timer};
 use mountain_mqtt::client::Client as _;
 use mountain_mqtt::client::{
-    ClientError, ClientReceivedEvent, ConnectionSettings, EventHandlerError,
+    ClientError, ClientReceivedEvent, ConnectionSettings, EventHandlerError, FromApplicationMessage,
 };
 use mountain_mqtt::{client_state::ClientStateNoQueue, data::quality_of_service::QualityOfService};
 use mountain_mqtt_embassy::handler_client::SyncEventHandler;
-use mountain_mqtt_embassy::mqtt_manager::FromApplicationMessage;
 use mountain_mqtt_embassy::poll_client::{self, PollClient, Settings};
 use {defmt_rtt as _, panic_probe as _};
 

--- a/embassy-poll-example-rp2040w/src/mqtt_poll.rs
+++ b/embassy-poll-example-rp2040w/src/mqtt_poll.rs
@@ -7,11 +7,9 @@ use embassy_futures::select::{select, Either};
 use embassy_net::Stack;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, Timer};
-use mountain_mqtt::client::ClientError;
-use mountain_mqtt::client::ConnectionSettings;
+use mountain_mqtt::client::{ClientError, ConnectionSettings, FromApplicationMessage};
 use mountain_mqtt::client_state::ClientStateNoQueue;
 use mountain_mqtt::data::quality_of_service::QualityOfService;
-use mountain_mqtt_embassy::mqtt_manager::FromApplicationMessage;
 use mountain_mqtt_embassy::packet_bin::PacketBin;
 use mountain_mqtt_embassy::poll_client::{self, PollClient, Settings};
 

--- a/mountain-mqtt-embassy/Cargo.toml
+++ b/mountain-mqtt-embassy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountain-mqtt-embassy"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["mqtt", "embassy"]
@@ -40,7 +40,7 @@ log = { version = "0.4", optional = true }
 
 embedded-io-async = { version = "0.6.1" }
 
-mountain-mqtt = { version = "0.2.0", path = "../mountain-mqtt", default-features = false, features = [
+mountain-mqtt = { version = "0.3.0", path = "../mountain-mqtt", default-features = false, features = [
   "embedded-io-async",
   "embedded-hal-async",
 ] }

--- a/mountain-mqtt-embassy/src/mqtt_manager.rs
+++ b/mountain-mqtt-embassy/src/mqtt_manager.rs
@@ -5,22 +5,12 @@ use embassy_sync::channel::{Receiver, Sender};
 use embassy_time::{Delay, Duration, Instant, Timer};
 use mountain_mqtt::client::{
     Client, ClientError, ClientNoQueue, ClientReceivedEvent, ConnectionSettings, EventHandler,
-    EventHandlerError,
+    EventHandlerError, FromApplicationMessage,
 };
 use mountain_mqtt::data::quality_of_service::QualityOfService;
 use mountain_mqtt::embedded_hal_async::DelayEmbedded;
 use mountain_mqtt::embedded_io_async::ConnectionEmbedded;
 use mountain_mqtt::mqtt_manager::{ConnectionId, MqttOperations};
-use mountain_mqtt::packets::publish::ApplicationMessage;
-
-/// Convert an [ApplicationMessage] to an application-specific event type
-/// This is a specific trait rather than [TryFrom] so it can use a specific
-/// error type, and include the expected number of properties in the
-/// [ApplicationMessage].
-pub trait FromApplicationMessage<const P: usize>: Sized {
-    fn from_application_message(message: &ApplicationMessage<P>)
-        -> Result<Self, EventHandlerError>;
-}
 
 /// Represents an error while running MQTT connections
 /// These are passed to the [MqttEvent] channel in

--- a/mountain-mqtt-embassy/src/packet_bin_client.rs
+++ b/mountain-mqtt-embassy/src/packet_bin_client.rs
@@ -64,7 +64,6 @@ where
             r.position()
         };
         let packet = PacketBin { buf, len };
-        buf[0] = 1;
         self.send(packet).await;
         Ok(())
     }

--- a/mountain-mqtt/Cargo.toml
+++ b/mountain-mqtt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountain-mqtt"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["mqtt", "tokio", "embedded-hal-async"]

--- a/mountain-mqtt/src/client.rs
+++ b/mountain-mqtt/src/client.rs
@@ -23,6 +23,15 @@ use crate::{
     },
 };
 
+/// Convert an [ApplicationMessage] to an application-specific event type
+/// This is a specific trait rather than [TryFrom] so it can use a specific
+/// error type, and include the expected number of properties in the
+/// [ApplicationMessage].
+pub trait FromApplicationMessage<const P: usize>: Sized {
+    fn from_application_message(message: &ApplicationMessage<P>)
+        -> Result<Self, EventHandlerError>;
+}
+
 /// Errors produced when a [ClientNoQueue] event handler cannot handle
 /// a [ClientReceivedEvent]. These errors propagate to the user of the
 /// client, and so are likely to cause the client to be disconnected.


### PR DESCRIPTION
This trait is generally useful outside embassy, and doesn't introduce any dependencies into main crate.